### PR TITLE
Bugfix: Allow a singleton with self edge as input

### DIFF
--- a/src/graph.h
+++ b/src/graph.h
@@ -37,13 +37,13 @@ public:
 	using edge_t = std::pair<edge_label_t[2], double>;
 
 	EdgesCollection(size_t preallocSize) {
-		data.reserve(preallocSize); 
+		data.reserve(preallocSize);
 	}
 
 	void clear() override { data.clear(); }
 
 	std::vector<edge_t> data;
-	
+
 	int maxEdge{ 0 };
 };
 
@@ -52,7 +52,7 @@ public:
 class Graph {
 
 protected:
-	int numThreads; 
+	int numThreads;
 
 	int sequenceColumnIds[2]{ 0, 1 };
 
@@ -65,17 +65,17 @@ public:
 	static bool isNewline(char c) { return c == '\r' || c == '\n'; }
 
 	Graph(int numThreads) : numThreads(std::max(4, numThreads)) {}; // at least three - loader,parser,updater
-		 
+
 	virtual ~Graph() {}
 
 	virtual IMatrix& getMatrix() = 0;
-	
+
 	virtual size_t getNumVertices() const = 0;
 
 	virtual size_t getNumInputVertices() const = 0;
 
 	virtual size_t getNumEdges() const = 0;
-		
+
 	virtual size_t load(
 		std::ifstream& ifs,
 		const std::pair<std::string, std::string>& idColumns,
@@ -117,8 +117,8 @@ protected:
 	void fillRepresentatives(
 		const std::vector<std::tuple<object_t, int, Ts...>>& objects_and_clusters,
 		std::vector<std::tuple<object_t, object_t>>& objects_and_representatives) const;
-	
-	
+
+
 };
 
 
@@ -128,6 +128,7 @@ void Graph::fillRepresentatives(
 	const std::vector<std::tuple<object_t, int, Ts...>> & objects_and_clusters,
 	std::vector<std::tuple<object_t, object_t>>& objects_and_representatives) const {
 
+
 	auto representative = std::get<0>(objects_and_clusters.front());
 	int cluster = std::get<1>(objects_and_clusters.front());
 
@@ -136,13 +137,13 @@ void Graph::fillRepresentatives(
 	for (int i = 0; i < (int)objects_and_clusters.size(); ++i) {
 		const auto& in = objects_and_clusters[i];
 		auto& out = objects_and_representatives[i];
-	
+
 		// update representative
 		if (std::get<1>(in) != cluster) {
 			cluster = std::get<1>(in);
 			representative = std::get<0>(in);
 		}
-		
+
 		std::get<0>(out) = std::get<0>(in);
 		std::get<1>(out) = representative;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 
 using namespace std;
 
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
 	try {
 
@@ -27,12 +27,17 @@ int main(int argc, char** argv)
 		if (!console.init(argc, argv, params)) {
 			return 0;
 		}
-	
+
 		std::unique_ptr<Graph> graph = console.loadGraph(params);
 
 		console.loadObjects(params, *graph, objects, names);
 		if (graph->getNumEdges() > 0) {
 			console.doClustering(params, *graph, objects, assignments);
+		}
+		else if (graph->getNumVertices() > 0) {
+			// No edges but have vertices: each vertex is its own singleton cluster
+			assignments.resize(graph->getNumVertices());
+			std::iota(assignments.begin(), assignments.end(), 0);
 		}
 		console.saveAssignments(params, *graph, names, assignments);
 

--- a/test/synth/synth.bat
+++ b/test/synth/synth.bat
@@ -1,13 +1,15 @@
 set EXE="D:/Projekty/clusty-dev/src/x64/Release/clusty.exe"
 
 %EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.clusty
-%EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.objs.clusty --objects-file synth.ids 
+%EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.objs.clusty --objects-file synth.ids
 
-%EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.reps.clusty --out-representatives 
-%EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.objs.reps.clusty --objects-file synth.ids --out-representatives 
+%EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.reps.clusty --out-representatives
+%EXE% --id-cols id1 id2 --distance-col ani --similarity --min ani 0.70 --numeric-ids synth.ani numeric.objs.reps.clusty --objects-file synth.ids --out-representatives
 
 %EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.clusty
-%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.objs.clusty --objects-file synth.ids 
+%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.objs.clusty --objects-file synth.ids
 
-%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.reps.clusty --out-representatives 
-%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.objs.reps.clusty --objects-file synth.ids --out-representatives 
+%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.reps.clusty --out-representatives
+%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.ani named.objs.reps.clusty --objects-file synth.ids --out-representatives
+
+%EXE% --id-cols name1 name2 --distance-col ani --similarity --min ani 0.70 synth.singleton.ani named.objs.reps.clusty --objects-file synth.ids --out-representatives

--- a/test/synth/synth.singleton.ani
+++ b/test/synth/synth.singleton.ani
@@ -1,0 +1,2 @@
+name1	name2	id1	id2	ani
+xxx	xxx	10	11	0.93


### PR DESCRIPTION
Hi,

I was running into an issue with clusty when I was giving it a file ANI file with only a single vertice & an edge to itself. 
For example: 
```txt
name1	name2	id1	id2	ani
xxx	xxx	10	11	0.93
```

Originally, one would get the following error: 
```bash 
Clusty
  version 1.2.2-b687638 (2025-05-22)

Loading pairwise distances from synth.singleton.ani ... 
  input graph: 0 nodes, 1 edges
  filtered graph: 0 nodes, 0 edges
  time [s]: 0.0316375
Saving clusters (representatives = true)... 
 41 Segmentation fault      (core dumped)
```

I was wondering if it would be possible to implement the following fix: 

- Allow self edges in `parseBlock` 
- Remove self edges in `updateMatrix`
- Writing output file with only singletons in `main.cpp` 

Sorry if the PR looks messy, my linter deleted a bunch of unnecessary spaces. I can reinclude the spaces if you want to make the diff easier.